### PR TITLE
Add Nuclino->Google Docs sync script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Nuclino to Google Docs Sync
+
+This repository contains a simple Python script that reads the contents of a Nuclino workspace and replicates those pages as Google Docs inside a chosen Google Drive folder.
+
+## Requirements
+
+* Python 3.8+
+* `requests`
+* `google-api-python-client`
+* A Nuclino API token
+* Google service account credentials with access to Drive and Docs
+
+Install dependencies:
+
+```bash
+pip install requests google-api-python-client google-auth-httplib2 google-auth-oauthlib
+```
+
+## Usage
+
+Set the required credentials either via command line flags or environment variables.
+
+```
+NUCLINO_TOKEN=<nuclino-token>
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+```
+
+Then run the script:
+
+```bash
+python nuclino_to_google_docs.py <workspace_id> <drive_folder_id>
+```
+
+All items inside the Nuclino workspace will be converted into Google Docs within the provided Drive folder. The document text is inserted at index `1` of the newly created Google Doc.

--- a/nuclino_to_google_docs.py
+++ b/nuclino_to_google_docs.py
@@ -1,0 +1,105 @@
+import os
+import json
+import requests
+from typing import Dict, Any, List
+
+from google.oauth2.service_account import Credentials
+from googleapiclient.discovery import build
+
+
+class NuclinoClient:
+    """Client for interacting with the Nuclino API."""
+
+    BASE_URL = "https://api.nuclino.com/v0.5"
+
+    def __init__(self, token: str):
+        self.token = token
+        self.headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
+
+    def get_workspace_items(self, workspace_id: str) -> List[Dict[str, Any]]:
+        """Return items in a Nuclino workspace."""
+        url = f"{self.BASE_URL}/workspaces/{workspace_id}/items"
+        resp = requests.get(url, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json().get("data", [])
+
+    def get_item_content(self, item_id: str) -> str:
+        """Return content of a Nuclino item."""
+        url = f"{self.BASE_URL}/items/{item_id}"
+        resp = requests.get(url, headers=self.headers)
+        resp.raise_for_status()
+        data = resp.json().get("data", {})
+        return data.get("body", "")
+
+
+class GoogleDriveClient:
+    """Client for Google Drive and Google Docs APIs."""
+
+    def __init__(self, credentials_path: str):
+        scopes = [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/documents",
+        ]
+        creds = Credentials.from_service_account_file(credentials_path, scopes=scopes)
+        self.drive_service = build("drive", "v3", credentials=creds)
+        self.docs_service = build("docs", "v1", credentials=creds)
+
+    def create_folder(self, name: str, parent_id: str = None) -> str:
+        """Create a folder on Google Drive and return its ID."""
+        file_metadata = {
+            "name": name,
+            "mimeType": "application/vnd.google-apps.folder",
+        }
+        if parent_id:
+            file_metadata["parents"] = [parent_id]
+        folder = self.drive_service.files().create(body=file_metadata, fields="id").execute()
+        return folder.get("id")
+
+    def create_document(self, name: str, content: str, parent_id: str) -> str:
+        """Create a Google Doc in the specified Drive folder."""
+        file_metadata = {
+            "name": name,
+            "mimeType": "application/vnd.google-apps.document",
+            "parents": [parent_id],
+        }
+        gfile = self.drive_service.files().create(body=file_metadata, fields="id").execute()
+        document_id = gfile.get("id")
+        if content:
+            requests = [{"insertText": {"location": {"index": 1}, "text": content}}]
+            self.docs_service.documents().batchUpdate(documentId=document_id, body={"requests": requests}).execute()
+        return document_id
+
+
+def sync_workspace(nuclino: NuclinoClient, gdrive: GoogleDriveClient, workspace_id: str, drive_root_id: str):
+    """Sync the entire Nuclino workspace into Google Drive."""
+    items = nuclino.get_workspace_items(workspace_id)
+    for item in items:
+        name = item.get("title")
+        item_id = item.get("id")
+        if not name or not item_id:
+            continue
+        content = nuclino.get_item_content(item_id)
+        gdrive.create_document(name, content, drive_root_id)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Sync a Nuclino workspace to Google Drive")
+    parser.add_argument("workspace_id", help="Nuclino workspace ID")
+    parser.add_argument("drive_folder_id", help="Google Drive folder ID where docs will be created")
+    parser.add_argument("--token", help="Nuclino API token", default=os.getenv("NUCLINO_TOKEN"))
+    parser.add_argument("--credentials", help="Path to Google service account credentials", default=os.getenv("GOOGLE_APPLICATION_CREDENTIALS"))
+
+    args = parser.parse_args()
+    if not args.token:
+        raise SystemExit("Nuclino token is required")
+    if not args.credentials:
+        raise SystemExit("Google credentials path is required")
+
+    nuclino_client = NuclinoClient(args.token)
+    gdrive_client = GoogleDriveClient(args.credentials)
+    sync_workspace(nuclino_client, gdrive_client, args.workspace_id, args.drive_folder_id)


### PR DESCRIPTION
## Summary
- add Python script to crawl Nuclino workspace
- push pages into Google Drive as Google Docs
- document usage
- ignore compiled artifacts

## Testing
- `python -m py_compile nuclino_to_google_docs.py`


------
https://chatgpt.com/codex/tasks/task_e_684115861af8832b82e778af656c1c1d